### PR TITLE
3.0.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rvpacker-txt-rs"
-version = "2.1.0"
+version = "3.0.0"
 edition = "2021"
 
 [dependencies]

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,21 +1,17 @@
 use clap::{value_parser, Arg, ArgAction, ArgMatches, Command};
 use color_print::{cformat, cstr};
-use indexmap::IndexSet;
 use once_cell::sync::Lazy;
 use regex::Regex;
-use sonic_rs::{from_str, from_value, json, prelude::*, to_string, Object};
+use sonic_rs::{from_str, json, prelude::*, to_string, Object};
 use std::{
     fs::{create_dir_all, read_to_string, write},
-    hash::BuildHasherDefault,
     io::stdin,
-    mem::take,
+    mem::transmute,
     path::{Path, PathBuf},
     process::exit,
-    str::CharIndices,
     time::Instant,
 };
 use sys_locale::get_locale;
-use xxhash_rust::xxh3::Xxh3;
 
 mod read;
 mod write;
@@ -26,32 +22,15 @@ enum GameType {
     LisaRPG,
 }
 
-impl PartialEq<GameType> for &GameType {
-    fn eq(&self, other: &GameType) -> bool {
-        *self == other
-    }
-}
-
-#[derive(PartialEq)]
+#[repr(u8)]
+#[derive(PartialEq, Clone, Copy)]
 enum ProcessingMode {
     Force,
     Append,
     Default,
 }
 
-impl AsRef<ProcessingMode> for ProcessingMode {
-    fn as_ref(&self) -> &ProcessingMode {
-        self
-    }
-}
-
-impl PartialEq<ProcessingMode> for &ProcessingMode {
-    fn eq(&self, other: &ProcessingMode) -> bool {
-        *self == other
-    }
-}
-
-#[derive(PartialEq)]
+#[derive(PartialEq, Clone, Copy)]
 enum EngineType {
     New,
     VXAce,
@@ -59,23 +38,12 @@ enum EngineType {
     XP,
 }
 
-impl AsRef<EngineType> for EngineType {
-    fn as_ref(&self) -> &EngineType {
-        self
-    }
-}
-
-impl PartialEq<EngineType> for &EngineType {
-    fn eq(&self, other: &EngineType) -> bool {
-        *self == other
-    }
-}
-
+#[derive(PartialEq)]
 enum Code {
     Dialogue, // also goes for credit
     Choice,
     System,
-    Unknown,
+    Misc,
 }
 
 enum Language {
@@ -95,6 +63,15 @@ enum Variable {
     Note,
 }
 
+#[derive(PartialEq, Clone, Copy)]
+#[repr(u8)]
+#[allow(dead_code)]
+enum MapsProcessingMode {
+    Default = 0,
+    Separate = 1,
+    Preserve = 2,
+}
+
 struct Localization<'a> {
     // About message and templates
     about_msg: &'a str,
@@ -104,6 +81,7 @@ struct Localization<'a> {
     // Command descriptions
     read_command_desc: &'a str,
     write_command_desc: &'a str,
+    migrate_command_desc: &'a str,
 
     // Argument descriptions
     input_dir_arg_read_desc: &'a str,
@@ -112,13 +90,9 @@ struct Localization<'a> {
     output_dir_arg_read_desc: &'a str,
     output_dir_arg_write_desc: &'a str,
 
-    shuffle_level_arg_desc: &'a str,
     disable_processing_arg_desc: &'a str,
 
     romanize_desc: &'a str,
-
-    force_arg_desc: &'a str,
-    append_arg_desc: &'a str,
 
     disable_custom_processing_desc: &'a str,
 
@@ -127,32 +101,34 @@ struct Localization<'a> {
     log_arg_desc: &'a str,
     help_arg_desc: &'a str,
 
-    separate_maps_flag_desc: &'a str,
+    processing_mode_arg_desc: &'a str,
+    maps_processing_mode_arg_desc: &'a str,
 
     // Argument types
-    input_dir_arg_type: &'a str,
-    output_dir_arg_type: &'a str,
+    number_arg_type: &'a str,
+    input_path_arg_type: &'a str,
+    output_path_arg_type: &'a str,
     disable_processing_arg_type: &'a str,
-    shuffle_arg_type: &'a str,
     language_arg_type: &'a str,
 
     // Messages and warnings
-    input_dir_not_exist: &'a str,
-    output_dir_not_exist: &'a str,
+    input_dir_missing: &'a str,
+    output_dir_missing: &'a str,
     original_dir_missing: &'a str,
-    translation_dirs_missing: &'a str,
+    translation_dir_missing: &'a str,
     file_written_msg: &'a str,
     file_parsed_msg: &'a str,
     file_already_parsed_msg: &'a str,
     file_is_not_parsed_msg: &'a str,
-    done_in_msg: &'a str,
+    elapsed_time_msg: &'a str,
     force_mode_warning: &'a str,
     custom_processing_enabled_msg: &'a str,
     enabling_romanize_metadata_msg: &'a str,
     disabling_custom_processing_metadata_msg: &'a str,
     no_subcommand_specified_msg: &'a str,
     could_not_determine_game_engine_msg: &'a str,
-    game_ini_file_not_found_msg: &'a str,
+    game_ini_file_missing_msg: &'a str,
+    enabling_maps_processing_mode_metadata_msg: &'a str,
 
     // Misc
     possible_values: &'a str,
@@ -162,20 +138,46 @@ struct Localization<'a> {
     when_writing: &'a str,
 }
 
+trait EachLine {
+    fn each_line(&self) -> Vec<String>;
+}
+
+// Return a Vec of strings splitted by lines (inclusive), akin to each_line in Ruby
+impl EachLine for str {
+    fn each_line(&self) -> Vec<String> {
+        let mut result: Vec<String> = Vec::new();
+        let mut current_line: String = String::new();
+
+        for char in self.chars() {
+            current_line.push(char);
+
+            if char == '\n' {
+                result.push(std::mem::take(&mut current_line));
+            }
+        }
+
+        if !current_line.is_empty() {
+            result.push(std::mem::take(&mut current_line));
+        }
+
+        result
+    }
+}
+
 impl Localization<'_> {
     fn new(language: Language) -> Self {
         match language {
-            Language::English => Self::load_english(),
-            Language::Russian => Self::load_russian(),
+            Language::English => Self::init_en(),
+            Language::Russian => Self::init_ru(),
         }
     }
 
-    fn load_english() -> Self {
+    fn init_en() -> Self {
         Localization {
             // About message and templates
             about_msg: cstr!(
                 "<bold>This tool allows to parse RPG Maker XP/VX/VXAce/MV/MZ games text to .txt files and write them \
-                 back to their initial form.</bold>"
+                 back to their initial form.</>"
             ),
             help_template: cstr!(
                 "{about}\n\n<underline,bold>Usage:</> rvpacker-txt-rs COMMAND \
@@ -187,10 +189,13 @@ impl Localization<'_> {
 
             // Command descriptions
             read_command_desc: cstr!(
-                r#"<bold>Parses files from "original" or "data" ("Data") folders of input directory to "translation" folder of output directory.</bold>"#
+                r#"<bold>Parses files from "original" or "data" ("Data") folders of input directory to "translation" folder of output directory.</>"#
             ),
             write_command_desc: cstr!(
-                r#"<bold>Writes translated files using original files from "original" or "data" ("Data") folders of input directory and writes results to "output" folder of output directory.</bold>"#
+                r#"<bold>Writes translated files using original files from "original" or "data" ("Data") folders of input directory and writes results to "output" folder of output directory.</>"#
+            ),
+            migrate_command_desc: cstr!(
+                r#"<bold>Migrates v1/v2 projects to v3 format. Note: maps names are implemented differently in v3, so you should do read --append after migrate, and then insert translated maps names next to Mapxxx.json comments that contain an original map name.</>"#
             ),
 
             // Argument descriptions
@@ -200,16 +205,10 @@ impl Localization<'_> {
             output_dir_arg_read_desc: r#"Output directory, where a "translation" folder with translation .txt files will be created."#,
             output_dir_arg_write_desc: r#"Output directory, where an "output" folder with "data" ("Data") and/or "js" subfolders with game files with translated text from .txt files will be created."#,
 
-            shuffle_level_arg_desc: "With value 1, shuffles all translation lines. With value 2, shuffles all words \
-                                     in translation lines.",
             disable_processing_arg_desc: "Skips processing specified files.",
 
             romanize_desc: r#"If you parsing text from a Japanese game, that contains symbols like 「」, which are just the Japanese quotation marks, it automatically replaces these symbols by their roman equivalents (in this case, ''). This flag will automatically be used when writing if you parsed game text with it."#,
 
-            force_arg_desc: "Force rewrite all files. Cannot be used with --append.",
-            append_arg_desc: "When the game, which files you've parsed, or the rvpacker-txt-rs updates, you probably \
-                              should re-read game files using --append flag, to append any unparsed text to the \
-                              existing without overwriting translation. Cannot be used with --force.",
 
             disable_custom_processing_desc: "Disables built-in custom processing, implemented for some games. This \
                                              flag will automatically be used when writing if you parsed game text \
@@ -219,28 +218,27 @@ impl Localization<'_> {
             log_arg_desc: "Enables logging.",
             help_arg_desc: "Prints the program's help message or for the entered subcommand.",
 
-            separate_maps_flag_desc: "Separates different Maps files's text to dedicated blocks. Note: This argument \
-                                     doesn't create multiple Maps txt files. It puts all text in one maps.txt file, \
-                                     but separates different files's text by <!-- MapXXX --> lines.",
+            processing_mode_arg_desc: "How to process files. default - Aborts processing if encounters already existing translation .txt files.\nappend - For example, if game you're translating updates, you can use this flag to append any new text to your existing files preserving lines order.\nforce - Force rewrites existing translation .txt files.",
+            maps_processing_mode_arg_desc: "How to process maps.\ndefault - Ignore all previously encountered text duplicates\nseparate - For each new map, reset the set of previously encountered text duplicates\npreserve - Allow all text duplicates.",
 
             // Argument types
-            input_dir_arg_type: "INPUT_PATH",
-            output_dir_arg_type: "OUTPUT_PATH",
-            disable_processing_arg_type: "FILENAMES",
-            shuffle_arg_type: "NUMBER",
+            number_arg_type: "NUMBER",
+            input_path_arg_type: "INPUT_PATH",
+            output_path_arg_type: "OUTPUT_PATH",
+            disable_processing_arg_type: "FILES",
             language_arg_type: "LANGUAGE",
 
             // Messages and warnings
-            input_dir_not_exist: "Input directory does not exist.",
-            output_dir_not_exist: "Output directory does not exist.",
+            input_dir_missing: "Input directory does not exist.",
+            output_dir_missing: "Output directory does not exist.",
             original_dir_missing: r#"The "original" or "data" ("Data") folder in the input directory does not exist."#,
-            translation_dirs_missing: r#"The "translation/maps" and/or "translation/other" folders in the input directory do not exist."#,
+            translation_dir_missing: r#"The "translation" folder in the input directory does not exist."#,
             file_written_msg: "Wrote file",
             file_parsed_msg: "Parsed file",
             file_already_parsed_msg: "file already exists. If you want to forcefully re-read all files, use --force \
                                       flag, or --append if you want append new text to already existing files.",
             file_is_not_parsed_msg: "Files aren't already parsed. Continuing as if --append flag was omitted.",
-            done_in_msg: "Done in:",
+            elapsed_time_msg: "Elapsed time:",
             force_mode_warning: "WARNING! Force mode will forcefully rewrite all your translation files in the \
                                  folder, including _trans. Input 'Y' to continue.",
             custom_processing_enabled_msg: "Custom processing for this game will be used. Use \
@@ -249,8 +247,10 @@ impl Localization<'_> {
             disabling_custom_processing_metadata_msg: "Disabling custom processing according to the metadata from \
                                                        previous read.",
             no_subcommand_specified_msg: "No command was specified. Call rvpacker-txt-rs -h for help.",
-            could_not_determine_game_engine_msg: "Couldn't determine game engine. Check the existence of System file inside your data/original directory.",
-            game_ini_file_not_found_msg: "Game.ini file not found.",
+            could_not_determine_game_engine_msg: "Couldn't determine game engine. Check the existence of System file \
+                                                  inside your data/original directory.",
+            game_ini_file_missing_msg: "Game.ini file not found.",
+            enabling_maps_processing_mode_metadata_msg: "Setting maps_processing_mode value to  according to the metadata from previous read.",
 
             // Misc
             possible_values: "Allowed values:",
@@ -261,11 +261,11 @@ impl Localization<'_> {
         }
     }
 
-    fn load_russian() -> Self {
+    fn init_ru() -> Self {
         Localization {
             about_msg: cstr!(
                 "<bold>Инструмент, позволяющий парсить текст из файлов RPG Maker XP/VX/VXAce/MV/MZ игр в .txt файлы, \
-                 а затем записывать их обратно в совместимые файлы.</bold>"
+                 а затем записывать их обратно в совместимые файлы.</>"
             ),
             help_template: cstr!(
                 "{about}\n\n<underline,bold>Использование:</> rvpacker-txt-rs КОМАНДА \
@@ -276,10 +276,13 @@ impl Localization<'_> {
             ),
 
             read_command_desc: cstr!(
-                r#"<bold>Парсит файлы из папки "original" или "data" ("Data") входной директории в папку "translation" выходной директории.</bold>"#
+                r#"<bold>Парсит файлы из папки "original" или "data" ("Data") входной директории в папку "translation" выходной директории.</>"#
             ),
             write_command_desc: cstr!(
-                r#"<bold>Записывает переведенные файлы, используя исходные файлы из папки "original" или "data" ("Data") входной директории, применяя текст из .txt файлов папки "translation", выводя результаты в папку "output" выходной директории.</bold>"#
+                r#"<bold>Записывает переведенные файлы, используя исходные файлы из папки "original" или "data" ("Data") входной директории, применяя текст из .txt файлов папки "translation", выводя результаты в папку "output" выходной директории.</>"#
+            ),
+            migrate_command_desc: cstr!(
+                r#"<bold>Переносит проекты версий v1/v2 в формат v3. Примечание: названия карт в версии 3 реализованы по-другому, поэтому вам следует выполнить read --append после переноса, а затем вставить переведенные названия карт рядом с комментариями Mapxxx.json, которые содержат оригинальное название карты.</>"#
             ),
 
             input_dir_arg_read_desc: r#"Входная директория, содержащая папку "original" или "data" ("Data") с оригинальными файлами игры."#,
@@ -288,17 +291,9 @@ impl Localization<'_> {
             output_dir_arg_read_desc: r#"Выходная директория, где будет создана папка "translation" с .txt файлами перевода."#,
             output_dir_arg_write_desc: r#"Выходная директория, где будет создана папка "output" с подпапками "data" ("Data") и/или "js", содержащими игровые файлы с переведённым текстом из .txt файлов."#,
 
-            shuffle_level_arg_desc: "При значении 1, перемешивает все строки перевода. При значении 2, перемешивает \
-                                     все слова в строках перевода.",
             disable_processing_arg_desc: "Не обрабатывает указанные файлы.",
 
             romanize_desc: r#"Если вы парсите текст из японской игры, содержащей символы вроде 「」, являющимися обычными японскими кавычками, программа автоматически заменяет эти символы на их европейские эквиваленты. (в данном случае, '')"#,
-
-            force_arg_desc: "Принудительно перезаписать все файлы. Не может быть использован с --append.",
-            append_arg_desc: "Когда игра, файлы которой вы распарсили, либо же rvpacker-txt-rs обновляется, вы, \
-                              наверное, должны перечитать файлы игры используя флаг --append, чтобы добавить любой \
-                              нераспарсенный текст к имеющемуся без перезаписи прогресса. Не может быть использован с \
-                              --force.",
 
             disable_custom_processing_desc: "Отключает использование индивидуальных способов обработки текста, \
                                              имплементированных для некоторых игр. Этот флаг будет автоматически \
@@ -308,27 +303,26 @@ impl Localization<'_> {
             log_arg_desc: "Включает логирование.",
             help_arg_desc: "Выводит справочную информацию по программе либо по введёной команде.",
 
-            separate_maps_flag_desc: "Разделяет текст из разных файлов Maps на отдельные блоки. Примечание: Этот \
-                                     аргумент не создает несколько файлов Maps.txt. Он помещает весь текст в один \
-                                     файл maps.txt, но разделяет текст из разных файлов строками <!-- MapXXX -->.",
+            processing_mode_arg_desc: "Как обрабатывать файлы. default - Стандартный режим. Прекращает обработку, если .txt файлы перевода уже существуют.\nappend - Режим добавления. Например, если переводимая вами игра обновится, вы можете использовать этот аргумент чтобы добавить любой новый текст в существующие файлы, сохраняя порядок линий.\nforce - Принудительный режим. Принудительный режим перезаписывает существующие .txt файлы.",
+            maps_processing_mode_arg_desc: "Как обрабатывать карты.\ndefault - Игнорировать дубликаты всего ранее встреченного текста.\nseparate - Для каждой новой карты, обновлять список ранее встреченного текста.\npreserve - Разрешить все дубликаты текста.",
 
-            input_dir_arg_type: "ВХОДНОЙ_ПУТЬ",
-            output_dir_arg_type: "ВЫХОДНОЙ_ПУТЬ",
+            number_arg_type: "ЧИСЛО",
+            input_path_arg_type: "ВХОДНОЙ_ПУТЬ",
+            output_path_arg_type: "ВЫХОДНОЙ_ПУТЬ",
             disable_processing_arg_type: "ИМЕНА_ФАЙЛОВ",
-            shuffle_arg_type: "ЦИФРА",
             language_arg_type: "ЯЗЫК",
 
-            input_dir_not_exist: "Входная директория не существует.",
-            output_dir_not_exist: "Выходная директория не существует.",
+            input_dir_missing: "Входная директория не существует.",
+            output_dir_missing: "Выходная директория не существует.",
             original_dir_missing: r#"Папка "original" или "data" ("Data") входной директории не существует."#,
-            translation_dirs_missing: r#"Папки "translation/maps" и/или "translation/other" входной директории не существуют."#,
+            translation_dir_missing: r#"Папка "translation" входной директории не существует."#,
             file_written_msg: "Записан файл",
             file_parsed_msg: "Распарсен файл",
             file_already_parsed_msg: "уже существует. Если вы хотите принудительно перезаписать все файлы, \
                                       используйте флаг --force, или --append если вы хотите добавить новый текст в \
                                       файлы.",
             file_is_not_parsed_msg: "Файлы ещё не распарсены. Продолжаем в режиме с выключенным флагом --append.",
-            done_in_msg: "Выполнено за:",
+            elapsed_time_msg: "Затраченное время:",
             force_mode_warning: "ПРЕДУПРЕЖДЕНИЕ! Принудительный режим полностью перепишет все ваши файлы перевода, \
                                  включая _trans-файлы. Введите Y, чтобы продолжить.",
             custom_processing_enabled_msg: "Индивидуальная обработка текста будет использована для этой игры. \
@@ -338,9 +332,10 @@ impl Localization<'_> {
             disabling_custom_processing_metadata_msg: "В соответсвии с метаданными из прошлого чтения, индивидуальная \
                                                        обработка текста будет выключена.",
             no_subcommand_specified_msg: "Команда не была указана. Вызовите rvpacker-txt-rs -h для помощи.",
-            could_not_determine_game_engine_msg:
-                "Не удалось определить движок игры. Убедитесь, что файл System существует.",
-            game_ini_file_not_found_msg: "Файл Game.ini не был обнаружен.",
+            could_not_determine_game_engine_msg: "Не удалось определить движок игры. Убедитесь, что файл System \
+                                                  существует.",
+            game_ini_file_missing_msg: "Файл Game.ini не был обнаружен.",
+            enabling_maps_processing_mode_metadata_msg: "Значение аргумента maps_processing_mode установлено на  в соответствии с метаданными из прошлого чтения.",
 
             possible_values: "Разрешённые значения:",
             example: "Пример:",
@@ -350,18 +345,6 @@ impl Localization<'_> {
         }
     }
 }
-
-pub static STRING_IS_ONLY_SYMBOLS_RE: Lazy<Regex> = Lazy::new(|| unsafe {
-    Regex::new(r#"^[.()+\-:;\[\]^~%&!№$@`*\/→×？?ｘ％▼|♥♪！：〜『』「」〽。…‥＝゠、，【】［］｛｝（）〔〕｟｠〘〙〈〉《》・\\#<>=_ー※▶ⅠⅰⅡⅱⅢⅲⅣⅳⅤⅴⅥⅵⅦⅶⅧⅷⅨⅸⅩⅹⅪⅺⅫⅻⅬⅼⅭⅽⅮⅾⅯⅿ\s0-9]+$"#).unwrap_unchecked()
-});
-pub static ENDS_WITH_IF_RE: Lazy<Regex> = Lazy::new(|| unsafe { Regex::new(r" if\(.*\)$").unwrap_unchecked() });
-pub static LISA_PREFIX_RE: Lazy<Regex> =
-    Lazy::new(|| unsafe { Regex::new(r"^(\\et\[[0-9]+\]|\\nbt)").unwrap_unchecked() });
-pub static INVALID_MULTILINE_VARIABLE_RE: Lazy<Regex> =
-    Lazy::new(|| unsafe { Regex::new(r"^#? ?<.*>.?$|^[a-z][0-9]$").unwrap_unchecked() });
-pub static INVALID_VARIABLE_RE: Lazy<Regex> =
-    Lazy::new(|| unsafe { Regex::new(r"^[+-]?[0-9]+$|^///|---|restrict eval").unwrap_unchecked() });
-pub static SELECT_WORDS_RE: Lazy<Regex> = Lazy::new(|| unsafe { Regex::new(r"\S+").unwrap_unchecked() });
 
 pub fn romanize_string(string: String) -> String {
     let mut result: String = String::with_capacity(string.capacity());
@@ -436,7 +419,7 @@ pub fn get_object_data(object: &Object) -> String {
     match object.get(&"__type") {
         Some(object_type) => {
             if object_type.as_str().is_some_and(|_type: &str| _type == "bytes") {
-                unsafe { String::from_utf8_unchecked(from_value(&object["data"]).unwrap_unchecked()) }
+                unsafe { String::from_utf8_unchecked(sonic_rs::from_value(&object["data"]).unwrap_unchecked()) }
             } else {
                 String::new()
             }
@@ -445,33 +428,13 @@ pub fn get_object_data(object: &Object) -> String {
     }
 }
 
-trait EachLine {
-    fn each_line(&self) -> Vec<String>;
-}
-
-// Return a Vec of strings splitted by lines (inclusive), akin to each_line in Ruby
-impl EachLine for str {
-    fn each_line(&self) -> Vec<String> {
-        let mut result: Vec<String> = Vec::new();
-        let mut current_line: String = String::new();
-
-        for char in self.chars() {
-            current_line.push(char);
-
-            if char == '\n' {
-                result.push(take(&mut current_line));
-            }
-        }
-
-        if !current_line.is_empty() {
-            result.push(take(&mut current_line));
-        }
-
-        result
-    }
-}
-
-pub fn extract_strings(ruby_code: &str, mode: bool) -> (IndexSet<String, BuildHasherDefault<Xxh3>>, Vec<usize>) {
+pub fn extract_strings(
+    ruby_code: &str,
+    mode: bool,
+) -> (
+    indexmap::IndexSet<String, std::hash::BuildHasherDefault<xxhash_rust::xxh3::Xxh3>>,
+    Vec<usize>,
+) {
     fn is_escaped(index: usize, string: &str) -> bool {
         let mut backslash_count: u8 = 0;
 
@@ -486,7 +449,8 @@ pub fn extract_strings(ruby_code: &str, mode: bool) -> (IndexSet<String, BuildHa
         backslash_count % 2 == 1
     }
 
-    let mut strings: IndexSet<String, BuildHasherDefault<Xxh3>> = IndexSet::default();
+    let mut strings: indexmap::IndexSet<String, std::hash::BuildHasherDefault<xxhash_rust::xxh3::Xxh3>> =
+        indexmap::IndexSet::default();
     let mut indices: Vec<usize> = Vec::new();
     let mut inside_string: bool = false;
     let mut inside_multiline_comment: bool = false;
@@ -515,7 +479,7 @@ pub fn extract_strings(ruby_code: &str, mode: bool) -> (IndexSet<String, BuildHa
             continue;
         }
 
-        let char_indices: CharIndices = line.char_indices();
+        let char_indices: std::str::CharIndices = line.char_indices();
 
         for (i, char) in char_indices {
             if !inside_string && char == '#' {
@@ -550,20 +514,31 @@ pub fn extract_strings(ruby_code: &str, mode: bool) -> (IndexSet<String, BuildHa
     (strings, indices)
 }
 
-fn get_game_type(game_title: String) -> Option<&'static GameType> {
+fn get_game_type(game_title: String) -> Option<GameType> {
     let lowercased: &str = &game_title.to_lowercase();
 
     let termina_re: Regex = unsafe { Regex::new(r"\btermina\b").unwrap_unchecked() };
     let lisarpg_re: Regex = unsafe { Regex::new(r"\blisa\b").unwrap_unchecked() };
 
     if termina_re.is_match(lowercased) {
-        Some(&GameType::Termina)
+        Some(GameType::Termina)
     } else if lisarpg_re.is_match(lowercased) {
-        Some(&GameType::LisaRPG)
+        Some(GameType::LisaRPG)
     } else {
         None
     }
 }
+
+static STRING_IS_ONLY_SYMBOLS_RE: Lazy<Regex> = Lazy::new(|| unsafe {
+    Regex::new(r#"^[.()+\-:;\[\]^~%&!№$@`*\/→×？?ｘ％▼|♥♪！：〜『』「」〽。…‥＝゠、，【】［］｛｝（）〔〕｟｠〘〙〈〉《》・\\#<>=_ー※▶ⅠⅰⅡⅱⅢⅲⅣⅳⅤⅴⅥⅵⅦⅶⅧⅷⅨⅸⅩⅹⅪⅺⅫⅻⅬⅼⅭⅽⅮⅾⅯⅿ\s0-9]+$"#).unwrap_unchecked()
+});
+static ENDS_WITH_IF_RE: Lazy<Regex> = Lazy::new(|| unsafe { Regex::new(r" if\(.*\)$").unwrap_unchecked() });
+static LISA_PREFIX_RE: Lazy<Regex> = Lazy::new(|| unsafe { Regex::new(r"^(\\et\[[0-9]+\]|\\nbt)").unwrap_unchecked() });
+static INVALID_MULTILINE_VARIABLE_RE: Lazy<Regex> =
+    Lazy::new(|| unsafe { Regex::new(r"^#? ?<.*>.?$|^[a-z][0-9]$").unwrap_unchecked() });
+static INVALID_VARIABLE_RE: Lazy<Regex> =
+    Lazy::new(|| unsafe { Regex::new(r"^[+-]?[0-9]+$|^///|---|restrict eval").unwrap_unchecked() });
+static _SELECT_WORDS_RE: Lazy<Regex> = Lazy::new(|| unsafe { Regex::new(r"\S+").unwrap_unchecked() });
 
 static NEW_LINE: &str = r"\#";
 static LINES_SEPARATOR: &str = "<#>";
@@ -644,7 +619,7 @@ fn main() {
         .long("input-dir")
         .global(true)
         .help(input_dir_arg_desc)
-        .value_name(localization.input_dir_arg_type)
+        .value_name(localization.input_path_arg_type)
         .value_parser(value_parser!(PathBuf))
         .default_value("./")
         .hide_default_value(true)
@@ -655,29 +630,11 @@ fn main() {
         .long("output-dir")
         .global(true)
         .help(output_dir_arg_desc)
-        .value_name(localization.output_dir_arg_type)
+        .value_name(localization.output_path_arg_type)
         .value_parser(value_parser!(PathBuf))
         .default_value("./")
         .hide_default_value(true)
         .display_order(1);
-
-    // TODO: Reimplement shuffle_level arg
-    let _shuffle_level_arg: Arg = Arg::new("shuffle-level")
-        .short('s')
-        .long("shuffle-level")
-        .action(ArgAction::Set)
-        .value_name(localization.shuffle_arg_type)
-        .default_value("0")
-        .value_parser(value_parser!(u8).range(0..=2))
-        .help(cformat!(
-            "{}\n{} --shuffle-level 1.<bold>\n[{} 0, 1, 2]\n[{} 0]</bold>",
-            localization.shuffle_level_arg_desc,
-            localization.example,
-            localization.possible_values,
-            localization.default_value,
-        ))
-        .hide_default_value(true)
-        .display_order(2);
 
     let disable_processing_arg: Arg = Arg::new("disable-processing")
         .long("disable-processing")
@@ -685,7 +642,7 @@ fn main() {
         .value_delimiter(',')
         .value_name(localization.disable_processing_arg_type)
         .help(cformat!(
-            "{}\n{} --disable-processing=maps,other,system.<bold>\n[{} maps, other, system, plugins]</bold>",
+            "{}\n{} --disable-processing=maps,other,system\n<bold>[{} maps, other, system, plugins]</>",
             localization.disable_processing_arg_desc,
             localization.example,
             localization.possible_values,
@@ -702,35 +659,18 @@ fn main() {
         .help(localization.romanize_desc)
         .display_order(4);
 
-    let separate_maps_flag: Arg = Arg::new("separate-maps")
-        .long("separate-maps")
-        .alias("sep")
-        .help(localization.separate_maps_flag_desc)
-        .global(true)
-        .action(ArgAction::SetTrue);
-
-    // TODO: implement preserve_duplicates flag to parse ALL text from files
-    // without eliminating any duplicates
-    let _preserve_duplicates_flag = Arg::new("preserve-duplicates")
+    let processing_mode_arg: Arg = Arg::new("processing-mode")
         .short('p')
-        .long("preserve-duplicates")
-        .action(ArgAction::SetTrue)
-        .help("");
-
-    let force_flag: Arg = Arg::new("force")
-        .short('f')
-        .long("force")
-        .action(ArgAction::SetTrue)
-        .help(localization.force_arg_desc)
-        .display_order(95)
-        .conflicts_with("append");
-
-    let append_flag: Arg = Arg::new("append")
-        .short('a')
-        .long("append")
-        .action(ArgAction::SetTrue)
-        .help(localization.append_arg_desc)
-        .display_order(96);
+        .long("processing-mode")
+        .value_parser(["default", "append", "force"])
+        .default_value("default")
+        .value_name(localization.number_arg_type)
+        .help(cformat!(
+            "{}\n<bold>[{} default, append, force] [{} default]</>",
+            localization.processing_mode_arg_desc,
+            localization.possible_values,
+            localization.default_value
+        ));
 
     let disable_custom_processing_flag: Arg = Arg::new("disable-custom-processing")
         .long("disable-custom-processing")
@@ -746,7 +686,7 @@ fn main() {
         .value_name(localization.language_arg_type)
         .global(true)
         .help(cformat!(
-            "{}\n{} --language en.<bold>\n[{} en, ru]</bold>",
+            "{}\n{} --language en<bold>\n[{} en, ru]</>",
             localization.language_arg_desc,
             localization.example,
             localization.possible_values,
@@ -768,13 +708,26 @@ fn main() {
         .action(ArgAction::Help)
         .display_order(100);
 
+    let maps_processing_mode_arg: Arg = Arg::new("maps-processing-mode")
+        .long("maps-processing-mode")
+        .alias("maps-mode")
+        .help(cformat!(
+            "{}\n<bold>[{} default, separate, preserve] [{} default]</>",
+            localization.maps_processing_mode_arg_desc,
+            localization.possible_values,
+            localization.default_value
+        ))
+        .value_parser(["default", "separate", "preserve"])
+        .default_value("default")
+        .global(true);
+
     let silent_flag: Arg = Arg::new("silent").long("silent").hide(true).action(ArgAction::SetTrue);
 
     let read_subcommand: Command = Command::new("read")
         .disable_help_flag(true)
         .help_template(localization.subcommand_help_template)
         .about(localization.read_command_desc)
-        .args([force_flag, append_flag, silent_flag])
+        .args([processing_mode_arg, silent_flag])
         .arg(&help_flag);
 
     let write_subcommand: Command = Command::new("write")
@@ -783,7 +736,11 @@ fn main() {
         .about(localization.write_command_desc)
         .arg(&help_flag);
 
-    let migrate_subcommand: Command = Command::new("migrate").disable_help_flag(true);
+    let migrate_subcommand: Command = Command::new("migrate")
+        .disable_help_flag(true)
+        .help_template(localization.subcommand_help_template)
+        .about(localization.migrate_command_desc)
+        .arg(&help_flag);
 
     let cli: Command = Command::new("")
         .disable_version_flag(true)
@@ -801,7 +758,7 @@ fn main() {
             romanize_arg,
             language_arg,
             disable_custom_processing_flag,
-            separate_maps_flag,
+            maps_processing_mode_arg,
             log_flag,
             help_flag,
         ])
@@ -835,13 +792,13 @@ fn main() {
     let input_dir: &Path = matches.get_one::<PathBuf>("input-dir").unwrap();
 
     if !input_dir.exists() {
-        panic!("{}", localization.input_dir_not_exist);
+        panic!("{}", localization.input_dir_missing);
     }
 
     let output_dir: &Path = matches.get_one::<PathBuf>("output-dir").unwrap();
 
     if !output_dir.exists() {
-        panic!("{}", localization.output_dir_not_exist)
+        panic!("{}", localization.output_dir_missing)
     }
 
     let mut original_path: &Path = &input_dir.join("original");
@@ -861,29 +818,34 @@ fn main() {
         output_dir
     };
 
-    let (output_path, metadata_file_path) = (
-        &root_dir.join("translation"),
-        &root_dir.join("translation/.rvpacker-txt-rs-metadata.json"),
-    );
+    let output_path: &Path = &root_dir.join("translation");
+    let metadata_file_path: &Path = &output_path.join(".rvpacker-txt-rs-metadata.json");
 
     let logging_flag: bool = matches.get_flag("log");
     let disable_custom_processing_flag: bool = matches.get_flag("disable-custom-processing");
-    let separate_maps_flag: bool = matches.get_flag("separate-maps");
     let mut romanize_flag: bool = matches.get_flag("romanize");
 
-    let (engine_type, system_file_path, scripts_file_path): (&EngineType, PathBuf, Option<PathBuf>) = {
+    let mut maps_processing_mode_value: MapsProcessingMode =
+        match matches.get_one::<String>("maps-processing-mode").unwrap().as_str() {
+            "default" => MapsProcessingMode::Default,
+            "separate" => MapsProcessingMode::Separate,
+            "preserve" => MapsProcessingMode::Preserve,
+            _ => unreachable!(),
+        };
+
+    let (engine_type, system_file_path, scripts_file_path): (EngineType, PathBuf, Option<PathBuf>) = {
         let mut system_path: PathBuf = original_path.join("System.json");
 
         if system_path.exists() {
             unsafe { EXTENSION = ".json" }
-            (&EngineType::New, system_path, None)
+            (EngineType::New, system_path, None)
         } else {
             system_path = original_path.join("System.rvdata2");
 
             if system_path.exists() {
                 unsafe { EXTENSION = ".rvdata2" }
                 (
-                    &EngineType::VXAce,
+                    EngineType::VXAce,
                     system_path,
                     Some(original_path.join("Scripts.rvdata2")),
                 )
@@ -892,13 +854,13 @@ fn main() {
 
                 if system_path.exists() {
                     unsafe { EXTENSION = ".rvdata" }
-                    (&EngineType::VX, system_path, Some(original_path.join("Scripts.rvdata")))
+                    (EngineType::VX, system_path, Some(original_path.join("Scripts.rvdata")))
                 } else {
                     system_path = original_path.join("System.rxdata");
 
                     if system_path.exists() {
                         unsafe { EXTENSION = ".rxdata" }
-                        (&EngineType::XP, system_path, Some(original_path.join("Scripts.rxdata")))
+                        (EngineType::XP, system_path, Some(original_path.join("Scripts.rxdata")))
                     } else {
                         panic!("{}", localization.could_not_determine_game_engine_msg)
                     }
@@ -907,7 +869,7 @@ fn main() {
         }
     };
 
-    let mut game_type: Option<&GameType> = if disable_custom_processing_flag {
+    let mut game_type: Option<GameType> = if disable_custom_processing_flag {
         None
     } else {
         let game_title: String = if engine_type == EngineType::New {
@@ -927,7 +889,7 @@ fn main() {
 
                 game_title.unwrap()
             } else {
-                panic!("{}", localization.game_ini_file_not_found_msg)
+                panic!("{}", localization.game_ini_file_missing_msg)
             }
         };
 
@@ -943,38 +905,39 @@ fn main() {
     if subcommand == "read" {
         use read::*;
 
-        let force_flag: bool = subcommand_matches.get_flag("force");
-        let append_flag: bool = subcommand_matches.get_flag("append");
+        let processing_mode: ProcessingMode = match subcommand_matches
+            .get_one::<String>("processing-mode")
+            .unwrap()
+            .as_str()
+        {
+            "default" => ProcessingMode::Default,
+            "append" => ProcessingMode::Append,
+            "force" => ProcessingMode::Force,
+            _ => unreachable!(),
+        };
+
         let silent_flag: bool = subcommand_matches.get_flag("silent");
 
-        let processing_mode: &ProcessingMode = &if force_flag {
-            if !silent_flag {
-                let start_time: Instant = Instant::now();
-                println!("{}", localization.force_mode_warning);
+        if processing_mode == ProcessingMode::Force && !silent_flag {
+            let start_time: Instant = Instant::now();
+            println!("{}", localization.force_mode_warning);
 
-                let mut buf: String = String::with_capacity(4);
-                stdin().read_line(&mut buf).unwrap();
+            let mut buf: String = String::with_capacity(4);
+            stdin().read_line(&mut buf).unwrap();
 
-                if buf.trim_end() != "Y" {
-                    exit(0);
-                }
-
-                wait_time += start_time.elapsed().as_secs_f64();
+            if buf.trim_end() != "Y" {
+                exit(0);
             }
 
-            ProcessingMode::Force
-        } else if append_flag {
-            ProcessingMode::Append
-        } else {
-            ProcessingMode::Default
-        };
+            wait_time += start_time.elapsed().as_secs_f64();
+        }
 
         create_dir_all(output_path).unwrap();
         create_dir_all(output_path).unwrap();
 
         write(
             metadata_file_path,
-            to_string(&json!({"romanize": romanize_flag, "disableCustomProcessing": disable_custom_processing_flag, "separateMaps": separate_maps_flag})).unwrap(),
+            to_string(&json!({"romanize": romanize_flag, "disableCustomProcessing": disable_custom_processing_flag, "mapsProcessingMode": maps_processing_mode_value as u8})).unwrap(),
         )
         .unwrap();
 
@@ -982,7 +945,7 @@ fn main() {
             read_map(
                 original_path,
                 output_path,
-                separate_maps_flag,
+                maps_processing_mode_value,
                 romanize_flag,
                 logging_flag,
                 game_type,
@@ -1042,7 +1005,7 @@ fn main() {
         use write::*;
 
         if !output_path.exists() {
-            panic!("{}", localization.translation_dirs_missing);
+            panic!("{}", localization.translation_dir_missing);
         }
 
         let (data_output_path, plugins_output_path) = if engine_type == EngineType::New {
@@ -1057,19 +1020,45 @@ fn main() {
         create_dir_all(data_output_path).unwrap();
 
         if metadata_file_path.exists() {
-            let metadata: Object = from_str(&read_to_string(metadata_file_path).unwrap()).unwrap();
+            let metadata: Object = unsafe { from_str(&read_to_string(metadata_file_path).unwrap()).unwrap_unchecked() };
 
-            let romanize_bool: bool = metadata["romanize"].as_bool().unwrap();
-            let disable_custom_processing_bool: bool = metadata["disableCustomProcessing"].as_bool().unwrap();
+            let romanize_metadata: bool = unsafe { metadata["romanize"].as_bool().unwrap_unchecked() };
+            let disable_custom_processing_metadata: bool =
+                unsafe { metadata["disableCustomProcessing"].as_bool().unwrap_unchecked() };
+            let maps_processing_mode_metadata: u8 =
+                unsafe { metadata["mapsProcessingMode"].as_u64().unwrap_unchecked() as u8 };
 
-            if romanize_bool {
+            if romanize_metadata {
                 println!("{}", localization.enabling_romanize_metadata_msg);
-                romanize_flag = romanize_bool;
+                romanize_flag = romanize_metadata;
             }
 
-            if disable_custom_processing_bool && game_type.is_some() {
+            if disable_custom_processing_metadata && game_type.is_some() {
                 println!("{}", localization.disabling_custom_processing_metadata_msg);
                 game_type = None;
+            }
+
+            if maps_processing_mode_metadata > 0 {
+                let (before, after) = unsafe {
+                    localization
+                        .enabling_maps_processing_mode_metadata_msg
+                        .split_once("  ")
+                        .unwrap_unchecked()
+                };
+
+                maps_processing_mode_value =
+                    unsafe { transmute::<u8, MapsProcessingMode>(maps_processing_mode_metadata) };
+
+                println!(
+                    "{} {} {}",
+                    before,
+                    match maps_processing_mode_value {
+                        MapsProcessingMode::Default => "default",
+                        MapsProcessingMode::Separate => "separate",
+                        MapsProcessingMode::Preserve => "preserve",
+                    },
+                    after
+                );
             }
         }
 
@@ -1078,12 +1067,12 @@ fn main() {
                 output_path,
                 original_path,
                 data_output_path,
+                maps_processing_mode_value,
                 romanize_flag,
-                separate_maps_flag,
                 logging_flag,
-                localization.file_written_msg,
                 game_type,
                 engine_type,
+                localization.file_written_msg,
             );
         }
 
@@ -1094,9 +1083,9 @@ fn main() {
                 data_output_path,
                 romanize_flag,
                 logging_flag,
-                localization.file_written_msg,
                 game_type,
                 engine_type,
+                localization.file_written_msg,
             );
         }
 
@@ -1107,12 +1096,12 @@ fn main() {
                 data_output_path,
                 romanize_flag,
                 logging_flag,
-                localization.file_written_msg,
                 engine_type,
+                localization.file_written_msg,
             );
         }
 
-        if !disable_plugins_processing && game_type.is_some_and(|game_type: &GameType| game_type == GameType::Termina) {
+        if !disable_plugins_processing && game_type.is_some_and(|game_type: GameType| game_type == GameType::Termina) {
             write_plugins(
                 &output_path.join("plugins.json"),
                 output_path,
@@ -1142,25 +1131,21 @@ fn main() {
         let mut original_filename: String = String::new();
 
         for path in [maps_path, other_path, plugins_path] {
-            let entries = std::fs::read_dir(path).unwrap().flatten();
-
-            for entry in entries {
+            for entry in std::fs::read_dir(path).unwrap().flatten() {
                 if !entry.file_name().to_str().unwrap().contains("trans") {
                     original_content = read_to_string(entry.path()).unwrap();
                     original_filename = entry.file_name().to_str().unwrap().to_owned();
                 } else {
                     translated_content = read_to_string(entry.path()).unwrap();
 
-                    let original_content_split = original_content.split('\n');
-                    let translated_content_split = translated_content.split('\n');
-
                     std::fs::write(
                         output_path.join(original_filename.as_str()),
-                        original_content_split
-                            .zip(translated_content_split)
-                            .map(|(original, translated)| format!("{original}{LINES_SEPARATOR}{translated}"))
-                            .collect::<Vec<_>>()
-                            .join("\n"),
+                        String::from_iter(
+                            original_content
+                                .split('\n')
+                                .zip(translated_content.split('\n'))
+                                .map(|(original, translated)| format!("{original}{LINES_SEPARATOR}{translated}\n")),
+                        ),
                     )
                     .unwrap();
                 }
@@ -1170,7 +1155,7 @@ fn main() {
 
     println!(
         "{} {}",
-        localization.done_in_msg,
+        localization.elapsed_time_msg,
         start_time.elapsed().as_secs_f64() - wait_time
     );
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -588,9 +588,15 @@ fn main() {
         let subcommand: Option<String> = preparse_matches.subcommand_name().map(str::to_owned);
         let language_arg: Option<&String> = preparse_matches.get_one::<String>("language");
 
-        let language: String = language_arg
-            .map(String::to_owned)
-            .unwrap_or(get_locale().unwrap_or(String::from("en_US")));
+        let language: String = language_arg.map(String::to_owned).unwrap_or_else(|| {
+            let locale: String = get_locale().unwrap_or(String::from("en_US"));
+
+            if let Some((lang, _)) = locale.split_once('_') {
+                lang.to_owned()
+            } else {
+                locale
+            }
+        });
 
         let language: Language = match language.as_str() {
             "ru" | "be" | "uk" => Language::Russian,

--- a/src/read.rs
+++ b/src/read.rs
@@ -1,8 +1,8 @@
 #![allow(clippy::too_many_arguments)]
 use crate::{
-    get_object_data, romanize_string, write::extract_strings, Code, EngineType, GameType, ProcessingMode, Variable,
-    ENDS_WITH_IF_RE, EXTENSION, INVALID_MULTILINE_VARIABLE_RE, INVALID_VARIABLE_RE, LISA_PREFIX_RE,
-    STRING_IS_ONLY_SYMBOLS_RE,
+    extract_strings, get_object_data, romanize_string, Code, EngineType, GameType, ProcessingMode, Variable,
+    ENDS_WITH_IF_RE, EXTENSION, INVALID_MULTILINE_VARIABLE_RE, INVALID_VARIABLE_RE, LINES_SEPARATOR, LISA_PREFIX_RE,
+    NEW_LINE, STRING_IS_ONLY_SYMBOLS_RE,
 };
 use encoding_rs::Encoding;
 use flate2::read::ZlibDecoder;
@@ -15,7 +15,7 @@ use std::{
     cell::UnsafeCell,
     ffi::OsString,
     fs::{read, read_dir, read_to_string, write, DirEntry},
-    hash::{BuildHasher, BuildHasherDefault},
+    hash::BuildHasherDefault,
     io::Read,
     path::Path,
     str::{from_utf8_unchecked, Chars},
@@ -24,27 +24,6 @@ use xxhash_rust::xxh3::Xxh3;
 
 type Xxh3IndexSet = IndexSet<String, BuildHasherDefault<Xxh3>>;
 type Xxh3IndexMap<'a, 'b> = IndexMap<&'a str, &'b str, BuildHasherDefault<Xxh3>>;
-
-trait Join {
-    fn join(&self, delimiter: &str) -> String;
-}
-
-impl<T: ToString + AsRef<str>, S: BuildHasher> Join for IndexSet<T, S> {
-    fn join(&self, delimiter: &str) -> String {
-        let mut joined: String = String::new();
-
-        if !self.is_empty() {
-            joined.push_str(unsafe { self.get_index(0).unwrap_unchecked() }.as_ref());
-
-            for item in self.iter().skip(1) {
-                joined.push_str(delimiter);
-                joined.push_str(item.as_ref());
-            }
-        }
-
-        joined
-    }
-}
 
 #[allow(clippy::single_match, clippy::match_single_binding, unused_mut)]
 fn parse_parameter(
@@ -99,7 +78,7 @@ fn parse_parameter(
         }
     }
 
-    Some(parameter.to_string())
+    Some(parameter.to_owned())
 }
 
 #[allow(clippy::single_match, clippy::match_single_binding, unused_mut)]
@@ -263,13 +242,13 @@ fn parse_variable(
                                         return None;
                                     }
 
-                                    variable_text = r"\#".to_string() + left;
+                                    variable_text = NEW_LINE.to_owned() + left;
                                 } else {
                                     if !variable_text.ends_with(['.', '%', '!', '"']) {
                                         return None;
                                     }
 
-                                    variable_text = r"\#".to_string() + &variable_text
+                                    variable_text = NEW_LINE.to_owned() + &variable_text
                                 }
                             } else {
                                 return None;
@@ -308,7 +287,7 @@ fn parse_list<'a>(
 
         if in_sequence && ![401, 405].contains(&code) {
             if !line.is_empty() {
-                let mut joined: String = line.join("\n").trim().replace('\n', r"\#");
+                let mut joined: String = line.join("\n").trim().replace('\n', NEW_LINE);
 
                 if romanize {
                     joined = romanize_string(joined);
@@ -341,13 +320,13 @@ fn parse_list<'a>(
             401 | 405 => {
                 let parameter_string: String = parameters[0]
                     .as_str()
-                    .map(str::to_string)
+                    .map(str::to_owned)
                     .unwrap_or(match parameters[0].as_object() {
                         Some(obj) => get_object_data(obj),
                         None => String::new(),
                     })
                     .trim()
-                    .to_string();
+                    .to_owned();
 
                 if !parameter_string.is_empty() {
                     in_sequence = true;
@@ -358,13 +337,13 @@ fn parse_list<'a>(
                 for i in 0..parameters[0].as_array().unwrap().len() {
                     let subparameter_string: String = parameters[0][i]
                         .as_str()
-                        .map(str::to_string)
+                        .map(str::to_owned)
                         .unwrap_or(match parameters[0][i].as_object() {
                             Some(obj) => get_object_data(obj),
                             None => String::new(),
                         })
                         .trim()
-                        .to_string();
+                        .to_owned();
 
                     if !subparameter_string.is_empty() {
                         let parsed: Option<String> =
@@ -388,13 +367,13 @@ fn parse_list<'a>(
             356 => {
                 let parameter_string: String = parameters[0]
                     .as_str()
-                    .map(str::to_string)
+                    .map(str::to_owned)
                     .unwrap_or(match parameters[0].as_object() {
                         Some(obj) => get_object_data(obj),
                         None => String::new(),
                     })
                     .trim()
-                    .to_string();
+                    .to_owned();
 
                 if !parameter_string.is_empty() {
                     let parsed: Option<String> =
@@ -417,13 +396,13 @@ fn parse_list<'a>(
             320 | 324 => {
                 let parameter_string: String = parameters[1]
                     .as_str()
-                    .map(str::to_string)
+                    .map(str::to_owned)
                     .unwrap_or(match parameters[1].as_object() {
                         Some(obj) => get_object_data(obj),
                         None => String::new(),
                     })
                     .trim()
-                    .to_string();
+                    .to_owned();
 
                 if !parameter_string.is_empty() {
                     let parsed: Option<String> =
@@ -448,7 +427,6 @@ fn parse_list<'a>(
     }
 }
 
-// ! In current implementation, function performs extremely inefficient inserting of owned string to both hashmap and a hashset
 /// Reads all Map files of maps_path and parses them into .txt files in output_path.
 /// # Parameters
 /// * `maps_path` - path to directory than contains game files
@@ -473,17 +451,14 @@ pub fn read_map(
     mut processing_mode: &ProcessingMode,
     (file_parsed_msg, file_already_parsed_msg, file_is_not_parsed_msg): (&str, &str, &str),
 ) {
-    let maps_output_path: &Path = &output_path.join("maps.txt");
-    let maps_trans_output_path: &Path = &output_path.join("maps_trans.txt");
-    let names_output_path: &Path = &output_path.join("names.txt");
-    let names_trans_output_path: &Path = &output_path.join("names_trans.txt");
+    let output_path: &Path = &output_path.join("maps.txt");
 
-    if processing_mode == ProcessingMode::Default && maps_trans_output_path.exists() {
+    if processing_mode == ProcessingMode::Default && output_path.exists() {
         println!("maps_trans.txt {file_already_parsed_msg}");
         return;
     }
 
-    let maps_obj_vec =
+    let obj_vec_iter =
         read_dir(original_path)
             .unwrap()
             .filter_map(|entry: Result<DirEntry, std::io::Error>| match entry {
@@ -501,7 +476,7 @@ pub fn read_map(
                             load(&read(entry.path()).unwrap(), None, Some("")).unwrap()
                         };
 
-                        Some((filename_str.to_string(), json))
+                        Some((filename_str.to_owned(), json))
                     } else {
                         None
                     }
@@ -509,51 +484,31 @@ pub fn read_map(
                 Err(_) => None,
             });
 
-    let mut maps_lines_vec: Vec<String> = Vec::new();
+    let mut lines_vec: Vec<String> = Vec::new();
 
-    let maps_lines: UnsafeCell<Xxh3IndexSet> = UnsafeCell::new(IndexSet::default());
-    let maps_lines_mut_ref: &mut Xxh3IndexSet = unsafe { &mut *maps_lines.get() };
-    let maps_lines_ref: &Xxh3IndexSet = unsafe { &*maps_lines.get() };
+    let lines: UnsafeCell<Xxh3IndexSet> = UnsafeCell::new(IndexSet::default());
+    let lines_mut_ref: &mut Xxh3IndexSet = unsafe { &mut *lines.get() };
+    let lines_ref: &Xxh3IndexSet = unsafe { &*lines.get() };
 
-    let names_lines: UnsafeCell<Xxh3IndexSet> = UnsafeCell::new(IndexSet::default());
-    let names_lines_mut_ref: &mut Xxh3IndexSet = unsafe { &mut *names_lines.get() };
-    let names_lines_ref: &Xxh3IndexSet = unsafe { &*names_lines.get() };
+    let mut lines_map: Xxh3IndexMap = IndexMap::default();
 
-    let mut maps_translation_map: Xxh3IndexMap = IndexMap::default();
-    let mut names_translation_map: Xxh3IndexMap = IndexMap::default();
-
-    let (maps_original_text, maps_translated_text, names_original_text, names_translated_text) =
-        if processing_mode == ProcessingMode::Append {
-            if maps_trans_output_path.exists() && names_trans_output_path.exists() {
-                (
-                    read_to_string(maps_output_path).unwrap(),
-                    read_to_string(maps_trans_output_path).unwrap(),
-                    read_to_string(names_output_path).unwrap(),
-                    read_to_string(names_trans_output_path).unwrap(),
-                )
-            } else {
-                println!("{file_is_not_parsed_msg}");
-                processing_mode = &ProcessingMode::Default;
-                (String::new(), String::new(), String::new(), String::new())
-            }
-        } else {
-            (String::new(), String::new(), String::new(), String::new())
-        };
+    let original_content: String = if processing_mode == ProcessingMode::Append {
+        read_to_string(output_path).unwrap()
+    } else {
+        String::new()
+    };
 
     if processing_mode == ProcessingMode::Append {
-        for (original, translated) in maps_original_text
-            .par_split('\n')
-            .collect::<Vec<_>>()
-            .into_iter()
-            .zip(maps_translated_text.par_split('\n').collect::<Vec<_>>())
-        {
-            maps_translation_map.insert(original, translated);
+        if output_path.exists() {
+            for line in original_content.split('\n') {
+                let (original, translated) = line.split_once(LINES_SEPARATOR).unwrap();
+                lines_map.insert(original, translated);
+            }
+        } else {
+            println!("{file_is_not_parsed_msg}");
+            processing_mode = &ProcessingMode::Default;
         }
-
-        for (original, translated) in names_original_text.split('\n').zip(names_translated_text.split('\n')) {
-            names_translation_map.insert(original, translated);
-        }
-    }
+    };
 
     // 401 - dialogue lines
     // 102 - dialogue choices array
@@ -575,49 +530,34 @@ pub fn read_map(
             )
         };
 
-    for (filename, obj) in maps_obj_vec {
+    for (filename, obj) in obj_vec_iter {
         let mut filename_comment: String = format!("<!-- {filename} -->");
 
         if let Some(display_name) = obj[display_name_label].as_str() {
             if !display_name.is_empty() {
-                let mut display_name_string: String = display_name.to_string();
+                let mut display_name_string: String = display_name.to_owned();
 
                 if romanize {
                     display_name_string = romanize_string(display_name_string);
                 }
 
-                names_lines_mut_ref.insert(display_name_string);
-                let string_ref: &str = unsafe { names_lines_ref.last().unwrap_unchecked() }.as_str();
-
                 filename_comment.insert(filename_comment.len() - 3, ' ');
-                filename_comment.insert_str(filename_comment.len() - 4, string_ref);
-
-                if processing_mode == ProcessingMode::Append && !names_translation_map.contains_key(string_ref) {
-                    names_translation_map.shift_insert(names_lines_ref.len() - 1, string_ref, "");
-                }
+                filename_comment.insert_str(filename_comment.len() - 4, &display_name_string);
             }
         }
 
         if separate_maps {
-            maps_lines_vec.extend(maps_lines_mut_ref.drain(..));
-            maps_lines_vec.push(filename_comment);
+            lines_vec.extend(lines_mut_ref.drain(..));
+            lines_vec.push(filename_comment);
 
             if processing_mode == ProcessingMode::Append {
-                maps_translation_map.shift_insert(
-                    maps_lines_ref.len() - 1,
-                    unsafe { maps_lines_ref.last().unwrap_unchecked() },
-                    "",
-                );
+                lines_map.shift_insert(lines_ref.len() - 1, unsafe { lines_ref.last().unwrap_unchecked() }, "");
             }
         } else {
-            maps_lines_mut_ref.insert(filename_comment);
+            lines_mut_ref.insert(filename_comment);
 
             if processing_mode == ProcessingMode::Append {
-                maps_translation_map.shift_insert(
-                    maps_lines_ref.len() - 1,
-                    unsafe { maps_lines_ref.last().unwrap_unchecked() },
-                    "",
-                );
+                lines_map.shift_insert(lines_ref.len() - 1, unsafe { lines_ref.last().unwrap_unchecked() }, "");
             }
         }
 
@@ -646,52 +586,57 @@ pub fn read_map(
                     engine_type,
                     processing_mode,
                     (code_label, parameters_label),
-                    &maps_lines,
-                    &mut maps_translation_map,
+                    &lines,
+                    &mut lines_map,
                 );
             }
         }
 
         if logging {
-            println!("{file_parsed_msg} {filename}.");
+            println!("{file_parsed_msg} {filename}");
         }
     }
 
-    let (maps_original_content, maps_translated_content, names_original_content, names_translated_content) =
-        if processing_mode == ProcessingMode::Append {
-            let maps_collected: (Vec<&str>, Vec<&str>) = maps_translation_map.into_iter().unzip();
-            let names_collected: (Vec<&str>, Vec<&str>) = names_translation_map.into_iter().unzip();
-
-            (
-                maps_collected.0.join("\n"),
-                maps_collected.1.join("\n"),
-                names_collected.0.join("\n"),
-                names_collected.1.join("\n"),
-            )
-        } else {
-            (
-                if separate_maps {
-                    maps_lines_vec.join("\n")
+    let output_content: String = if processing_mode == ProcessingMode::Append {
+        lines_map
+            .into_iter()
+            .map(|(original, translated)| format!("{original}{LINES_SEPARATOR}{translated}"))
+            .collect::<Vec<_>>()
+            .join("\n")
+    } else if separate_maps {
+        lines_vec
+            .into_iter()
+            .map(|line: String| {
+                if line.starts_with("<!-- Map") {
+                    line + LINES_SEPARATOR
+                } else if line.starts_with("<!--") {
+                    line
                 } else {
-                    maps_lines_ref.join("\n")
-                },
-                "\n".repeat(if separate_maps {
-                    maps_lines_vec.len().saturating_sub(1)
+                    line + LINES_SEPARATOR
+                }
+            })
+            .collect::<Vec<_>>()
+            .join("\n")
+    } else {
+        lines
+            .into_inner()
+            .into_iter()
+            .map(|line: String| {
+                if line.starts_with("<!-- Map") {
+                    line + LINES_SEPARATOR
+                } else if line.starts_with("<!--") {
+                    line
                 } else {
-                    maps_lines_ref.len().saturating_sub(1)
-                }),
-                names_lines_ref.join("\n"),
-                "\n".repeat(names_lines_ref.len().saturating_sub(1)),
-            )
-        };
+                    line + LINES_SEPARATOR
+                }
+            })
+            .collect::<Vec<_>>()
+            .join("\n")
+    };
 
-    write(maps_output_path, maps_original_content).unwrap();
-    write(maps_trans_output_path, maps_translated_content).unwrap();
-    write(names_output_path, names_original_content).unwrap();
-    write(names_trans_output_path, names_translated_content).unwrap();
+    write(output_path, output_content).unwrap();
 }
 
-// ! In current implementation, function performs extremely inefficient inserting of owned string to both hashmap and a hashset
 /// Reads all other files of original_path and parses them into .txt files in output_path.
 /// # Parameters
 /// * `original_path` - path to directory than contains game files
@@ -714,36 +659,38 @@ pub fn read_other(
     engine_type: &EngineType,
     (file_parsed_msg, file_already_parsed_msg, file_is_not_parsed_msg): (&str, &str, &str),
 ) {
-    let other_obj_arr_iter = read_dir(original_path)
-        .unwrap()
-        .filter_map(|entry: Result<DirEntry, std::io::Error>| match entry {
-            Ok(entry) => {
-                let filename_os_string: OsString = entry.file_name();
-                let filename: &str = unsafe { from_utf8_unchecked(filename_os_string.as_encoded_bytes()) };
-                let (name, _) = filename.split_once('.').unwrap();
+    let obj_arr_iter =
+        read_dir(original_path)
+            .unwrap()
+            .filter_map(|entry: Result<DirEntry, std::io::Error>| match entry {
+                Ok(entry) => {
+                    let filename_os_string: OsString = entry.file_name();
+                    let filename: &str = unsafe { from_utf8_unchecked(filename_os_string.as_encoded_bytes()) };
+                    let (name, _) = filename.split_once('.').unwrap();
 
-                if !name.starts_with("Map")
-                    && !matches!(name, "Tilesets" | "Animations" | "System" | "Scripts")
-                    && filename.ends_with(unsafe { EXTENSION })
-                {
-                    if game_type.is_some_and(|game_type: &GameType| game_type == GameType::Termina) && name == "States"
+                    if !name.starts_with("Map")
+                        && !matches!(name, "Tilesets" | "Animations" | "System" | "Scripts")
+                        && filename.ends_with(unsafe { EXTENSION })
                     {
-                        return None;
-                    }
+                        if game_type.is_some_and(|game_type: &GameType| game_type == GameType::Termina)
+                            && name == "States"
+                        {
+                            return None;
+                        }
 
-                    let json: Value = if engine_type == EngineType::New {
-                        from_str(&read_to_string(entry.path()).unwrap()).unwrap()
+                        let json: Value = if engine_type == EngineType::New {
+                            from_str(&read_to_string(entry.path()).unwrap()).unwrap()
+                        } else {
+                            load(&read(entry.path()).unwrap(), None, Some("")).unwrap()
+                        };
+
+                        Some((filename.to_owned(), json))
                     } else {
-                        load(&read(entry.path()).unwrap(), None, Some("")).unwrap()
-                    };
-
-                    Some((filename.to_string(), json))
-                } else {
-                    None
+                        None
+                    }
                 }
-            }
-            Err(_) => None,
-        });
+                Err(_) => None,
+            });
 
     let mut inner_processing_mode: &ProcessingMode = processing_mode;
 
@@ -799,46 +746,35 @@ pub fn read_other(
         )
     };
 
-    for (filename, obj_arr) in other_obj_arr_iter {
-        let other_processed_filename: String = filename[0..filename.rfind('.').unwrap()].to_lowercase();
+    for (filename, obj_arr) in obj_arr_iter {
+        let output_path: &Path = &output_path.join(filename[0..filename.rfind('.').unwrap()].to_lowercase() + ".txt");
 
-        let other_output_path: &Path = &output_path.join(other_processed_filename.clone() + ".txt");
-        let other_trans_output_path: &Path = &output_path.join(other_processed_filename + "_trans.txt");
-
-        if processing_mode == ProcessingMode::Default && other_trans_output_path.exists() {
-            println!("{} {file_already_parsed_msg}", other_trans_output_path.display());
+        if processing_mode == ProcessingMode::Default && output_path.exists() {
+            println!("{} {file_already_parsed_msg}", output_path.display());
             continue;
         }
 
-        let other_lines: UnsafeCell<Xxh3IndexSet> = UnsafeCell::new(IndexSet::default());
-        let other_lines_mut_ref: &mut Xxh3IndexSet = unsafe { &mut *other_lines.get() };
-        let other_lines_ref: &Xxh3IndexSet = unsafe { &*other_lines.get() };
+        let lines: UnsafeCell<Xxh3IndexSet> = UnsafeCell::new(IndexSet::default());
+        let lines_mut_ref: &mut Xxh3IndexSet = unsafe { &mut *lines.get() };
+        let lines_ref: &Xxh3IndexSet = unsafe { &*lines.get() };
 
-        let mut other_translation_map: Xxh3IndexMap = IndexMap::default();
+        let mut lines_map: Xxh3IndexMap = IndexMap::default();
 
-        let (original_other_text, translated_other_text) = if processing_mode == ProcessingMode::Append {
-            if other_trans_output_path.exists() {
-                (
-                    read_to_string(other_output_path).unwrap(),
-                    read_to_string(other_trans_output_path).unwrap(),
-                )
-            } else {
-                println!("{file_is_not_parsed_msg}");
-                inner_processing_mode = &ProcessingMode::Default;
-                (String::new(), String::new())
-            }
+        let original_content: String = if processing_mode == ProcessingMode::Append {
+            read_to_string(output_path).unwrap()
         } else {
-            (String::new(), String::new())
+            String::new()
         };
 
         if processing_mode == ProcessingMode::Append {
-            for (original, translated) in original_other_text
-                .par_split('\n')
-                .collect::<Vec<_>>()
-                .into_iter()
-                .zip(translated_other_text.par_split('\n').collect::<Vec<_>>())
-            {
-                other_translation_map.insert(original, translated);
+            if output_path.exists() {
+                for line in original_content.par_split('\n').collect::<Vec<_>>() {
+                    let (original, translated) = line.split_once(LINES_SEPARATOR).unwrap();
+                    lines_map.insert(original, translated);
+                }
+            } else {
+                println!("{file_is_not_parsed_msg}");
+                inner_processing_mode = &ProcessingMode::Default;
             }
         }
 
@@ -854,7 +790,7 @@ pub fn read_other(
                     "<Menu Category: Healing>",
                     "<Menu Category: Body bag>",
                 ] {
-                    other_lines_mut_ref.insert(string.to_string());
+                    lines_mut_ref.insert(string.to_owned());
                 }
             }
 
@@ -876,7 +812,7 @@ pub fn read_other(
 
                         if !variable_str.is_empty() {
                             let parsed: Option<(String, bool)> = parse_variable(
-                                variable_str.to_string(),
+                                variable_str.to_owned(),
                                 &variable_type,
                                 &filename,
                                 game_type,
@@ -889,16 +825,14 @@ pub fn read_other(
                                         continue;
                                     }
 
-                                    if let Some(last) = other_lines_mut_ref.pop() {
-                                        other_lines_mut_ref.insert(last.trim().to_string() + &parsed);
-                                        let string_ref: &str =
-                                            unsafe { other_lines_ref.last().unwrap_unchecked() }.as_str();
+                                    if let Some(last) = lines_mut_ref.pop() {
+                                        lines_mut_ref.insert(last.trim().to_owned() + &parsed);
+                                        let string_ref: &str = unsafe { lines_ref.last().unwrap_unchecked() }.as_str();
 
                                         // TODO: this shit rewrites the translation line but inserts RIGHT original line
                                         if inner_processing_mode == ProcessingMode::Append {
-                                            let (idx, _, value) =
-                                                other_translation_map.shift_remove_full(last.as_str()).unwrap();
-                                            other_translation_map.shift_insert(idx, string_ref, value);
+                                            let (idx, _, value) = lines_map.shift_remove_full(last.as_str()).unwrap();
+                                            lines_map.shift_insert(idx, string_ref, value);
                                         }
                                     }
                                     continue;
@@ -914,17 +848,17 @@ pub fn read_other(
                                     .split('\n')
                                     .map(str::trim)
                                     .collect::<Vec<_>>()
-                                    .join(r"\#")
+                                    .join(NEW_LINE)
                                     .trim()
-                                    .to_string();
+                                    .to_owned();
 
-                                other_lines_mut_ref.insert(replaced);
-                                let string_ref: &str = unsafe { other_lines_ref.last().unwrap_unchecked() }.as_str();
+                                lines_mut_ref.insert(replaced);
+                                let string_ref: &str = unsafe { lines_ref.last().unwrap_unchecked() }.as_str();
 
                                 if inner_processing_mode == ProcessingMode::Append
-                                    && !other_translation_map.contains_key(string_ref)
+                                    && !lines_map.contains_key(string_ref)
                                 {
-                                    other_translation_map.shift_insert(other_lines_ref.len() - 1, string_ref, "");
+                                    lines_map.shift_insert(lines_ref.len() - 1, string_ref, "");
                                 }
                             } else if variable_type == Variable::Name {
                                 continue 'obj;
@@ -964,25 +898,29 @@ pub fn read_other(
                         engine_type,
                         processing_mode,
                         (code_label, parameters_label),
-                        &other_lines,
-                        &mut other_translation_map,
+                        &lines,
+                        &mut lines_map,
                     );
                 }
             }
         }
 
-        let (original_content, translation_content) = if processing_mode == ProcessingMode::Append {
-            let collected: (Vec<&str>, Vec<&str>) = other_translation_map.into_iter().unzip();
-            (collected.0.join("\n"), collected.1.join("\n"))
+        let output_content: String = if processing_mode == ProcessingMode::Append {
+            lines_map
+                .into_iter()
+                .map(|(original, translated)| format!("{original}{LINES_SEPARATOR}{translated}"))
+                .collect::<Vec<_>>()
+                .join("\n")
         } else {
-            (
-                other_lines_mut_ref.join("\n"),
-                "\n".repeat(other_lines_ref.len().saturating_sub(1)),
-            )
+            lines
+                .into_inner()
+                .into_iter()
+                .map(|line: String| line + LINES_SEPARATOR)
+                .collect::<Vec<_>>()
+                .join("\n")
         };
 
-        write(other_output_path, original_content).unwrap();
-        write(other_trans_output_path, translation_content).unwrap();
+        write(output_path, output_content).unwrap();
 
         if logging {
             println!("{file_parsed_msg} {filename}");
@@ -990,7 +928,6 @@ pub fn read_other(
     }
 }
 
-// ! In current implementation, function performs extremely inefficient inserting of owned string to both hashmap and a hashset
 /// Reads System file of system_file_path and parses it into .txt file of output_path.
 /// # Parameters
 /// * `system_file_path` - path to directory than contains game files
@@ -1011,38 +948,36 @@ pub fn read_system(
     engine_type: &EngineType,
     (file_parsed_msg, file_already_parsed_msg, file_is_not_parsed_msg): (&str, &str, &str),
 ) {
-    let system_output_path: &Path = &output_path.join("system.txt");
-    let system_trans_output_path: &Path = &output_path.join("system_trans.txt");
+    let output_path: &Path = &output_path.join("system.txt");
 
-    if processing_mode == ProcessingMode::Default && system_trans_output_path.exists() {
-        println!("system_trans.txt {file_already_parsed_msg}");
+    if processing_mode == ProcessingMode::Default && output_path.exists() {
+        println!("system.txt {file_already_parsed_msg}");
         return;
     }
 
-    let system_obj: Value = if engine_type == EngineType::New {
+    let obj: Value = if engine_type == EngineType::New {
         from_str(&read_to_string(system_file_path).unwrap()).unwrap()
     } else {
         load(&read(system_file_path).unwrap(), None, Some("")).unwrap()
     };
 
-    let system_lines: UnsafeCell<Xxh3IndexSet> = UnsafeCell::new(IndexSet::default());
-    let system_lines_mut_ref: &mut Xxh3IndexSet = unsafe { &mut *system_lines.get() };
-    let system_lines_ref: &Xxh3IndexSet = unsafe { &*system_lines.get() };
+    let lines: UnsafeCell<Xxh3IndexSet> = UnsafeCell::new(IndexSet::default());
+    let lines_mut_ref: &mut Xxh3IndexSet = unsafe { &mut *lines.get() };
+    let lines_ref: &Xxh3IndexSet = unsafe { &*lines.get() };
 
-    let mut system_translation_map: Xxh3IndexMap = IndexMap::default();
+    let mut lines_map: Xxh3IndexMap = IndexMap::default();
 
-    let system_original_text: String = read_to_string(system_output_path).unwrap();
-    let system_translated_text: String = read_to_string(system_trans_output_path).unwrap();
+    let original_content: String = if processing_mode == ProcessingMode::Append {
+        read_to_string(output_path).unwrap()
+    } else {
+        String::new()
+    };
 
     if processing_mode == ProcessingMode::Append {
-        if system_trans_output_path.exists() {
-            for (original, translated) in system_original_text
-                .par_split('\n')
-                .collect::<Vec<_>>()
-                .into_iter()
-                .zip(system_translated_text.par_split('\n').collect::<Vec<_>>())
-            {
-                system_translation_map.insert(original, translated);
+        if output_path.exists() {
+            for line in original_content.par_split('\n').collect::<Vec<_>>() {
+                let (original, translated) = line.split_once(LINES_SEPARATOR).unwrap();
+                lines_map.insert(original, translated);
             }
         } else {
             println!("{file_is_not_parsed_msg}");
@@ -1051,20 +986,20 @@ pub fn read_system(
     }
 
     if engine_type != EngineType::New {
-        let str: &str = system_obj["__symbol__currency_unit"].as_str().unwrap().trim();
+        let str: &str = obj["__symbol__currency_unit"].as_str().unwrap().trim();
 
         if !str.is_empty() {
-            let mut string: String = str.to_string();
+            let mut string: String = str.to_owned();
 
             if romanize {
                 string = romanize_string(string)
             }
 
-            system_lines_mut_ref.insert(string);
-            let string_ref: &str = unsafe { system_lines_ref.last().unwrap_unchecked() }.as_str();
+            lines_mut_ref.insert(string);
+            let string_ref: &str = unsafe { lines_ref.last().unwrap_unchecked() }.as_str();
 
-            if processing_mode == ProcessingMode::Append && !system_translation_map.contains_key(string_ref) {
-                system_translation_map.shift_insert(system_lines_ref.len() - 1, string_ref, "");
+            if processing_mode == ProcessingMode::Append && !lines_map.contains_key(string_ref) {
+                lines_map.shift_insert(lines_ref.len() - 1, string_ref, "");
             }
         }
     }
@@ -1096,90 +1031,90 @@ pub fn read_system(
 
     // Armor types names
     // Normally it's system strings, but might be needed for some purposes
-    for string in system_obj[armor_types_label].as_array().unwrap() {
+    for string in obj[armor_types_label].as_array().unwrap() {
         let str: &str = string.as_str().unwrap().trim();
 
         if !str.is_empty() {
-            let mut string: String = str.to_string();
+            let mut string: String = str.to_owned();
 
             if romanize {
                 string = romanize_string(string)
             }
 
-            system_lines_mut_ref.insert(string);
-            let string_ref: &str = unsafe { system_lines_ref.last().unwrap_unchecked() }.as_str();
+            lines_mut_ref.insert(string);
+            let string_ref: &str = unsafe { lines_ref.last().unwrap_unchecked() }.as_str();
 
-            if processing_mode == ProcessingMode::Append && !system_translation_map.contains_key(string_ref) {
-                system_translation_map.shift_insert(system_lines_ref.len() - 1, string_ref, "");
+            if processing_mode == ProcessingMode::Append && !lines_map.contains_key(string_ref) {
+                lines_map.shift_insert(lines_ref.len() - 1, string_ref, "");
             }
         }
     }
 
     // Element types names
     // Normally it's system strings, but might be needed for some purposes
-    for string in system_obj[elements_label].as_array().unwrap() {
+    for string in obj[elements_label].as_array().unwrap() {
         let str: &str = string.as_str().unwrap().trim();
 
         if !str.is_empty() {
-            let mut string: String = str.to_string();
+            let mut string: String = str.to_owned();
 
             if romanize {
                 string = romanize_string(string)
             }
 
-            system_lines_mut_ref.insert(string);
-            let string_ref: &str = unsafe { system_lines_ref.last().unwrap_unchecked() }.as_str();
+            lines_mut_ref.insert(string);
+            let string_ref: &str = unsafe { lines_ref.last().unwrap_unchecked() }.as_str();
 
-            if processing_mode == ProcessingMode::Append && !system_translation_map.contains_key(string_ref) {
-                system_translation_map.shift_insert(system_lines_ref.len() - 1, string_ref, "");
+            if processing_mode == ProcessingMode::Append && !lines_map.contains_key(string_ref) {
+                lines_map.shift_insert(lines_ref.len() - 1, string_ref, "");
             }
         }
     }
 
     // Names of equipment slots
     if engine_type == EngineType::New {
-        for string in system_obj["equipTypes"].as_array().unwrap() {
+        for string in obj["equipTypes"].as_array().unwrap() {
             let str: &str = string.as_str().unwrap().trim();
 
             if !str.is_empty() {
-                let mut string: String = str.to_string();
+                let mut string: String = str.to_owned();
 
                 if romanize {
                     string = romanize_string(string)
                 }
 
-                system_lines_mut_ref.insert(string);
-                let string_ref: &str = unsafe { system_lines_ref.last().unwrap_unchecked() }.as_str();
+                lines_mut_ref.insert(string);
+                let string_ref: &str = unsafe { lines_ref.last().unwrap_unchecked() }.as_str();
 
-                if processing_mode == ProcessingMode::Append && !system_translation_map.contains_key(string_ref) {
-                    system_translation_map.shift_insert(system_lines_ref.len() - 1, string_ref, "");
+                if processing_mode == ProcessingMode::Append && !lines_map.contains_key(string_ref) {
+                    lines_map.shift_insert(lines_ref.len() - 1, string_ref, "");
                 }
             }
         }
     }
 
     // Names of battle options
-    for string in system_obj[skill_types_label].as_array().unwrap() {
+    for string in obj[skill_types_label].as_array().unwrap() {
         let str: &str = string.as_str().unwrap().trim();
 
         if !str.is_empty() {
-            let mut string: String = str.to_string();
+            let mut string: String = str.to_owned();
 
             if romanize {
                 string = romanize_string(string)
             }
 
-            system_lines_mut_ref.insert(string);
-            let string_ref: &str = unsafe { system_lines_ref.last().unwrap_unchecked() }.as_str();
+            lines_mut_ref.insert(string);
+            let string_ref: &str = unsafe { lines_ref.last().unwrap_unchecked() }.as_str();
 
-            if processing_mode == ProcessingMode::Append && !system_translation_map.contains_key(string_ref) {
-                system_translation_map.shift_insert(system_lines_ref.len() - 1, string_ref, "");
+            if processing_mode == ProcessingMode::Append && !lines_map.contains_key(string_ref) {
+                lines_map.shift_insert(lines_ref.len() - 1, string_ref, "");
             }
         }
     }
 
     // Game terms vocabulary
-    for (key, value) in system_obj[terms_label].as_object().unwrap() {
+    for (key, value) in obj[terms_label].as_object().unwrap() {
         if !key.starts_with("__symbol__") {
             continue;
         }
@@ -1190,18 +1125,17 @@ pub fn read_system(
                     str = str.trim();
 
                     if !str.is_empty() {
-                        let mut string: String = str.to_string();
+                        let mut string: String = str.to_owned();
 
                         if romanize {
                             string = romanize_string(string)
                         }
 
-                        system_lines_mut_ref.insert(string);
-                        let string_ref: &str = unsafe { system_lines_ref.last().unwrap_unchecked() }.as_str();
+                        lines_mut_ref.insert(string);
+                        let string_ref: &str = unsafe { lines_ref.last().unwrap_unchecked() }.as_str();
 
-                        if processing_mode == ProcessingMode::Append && !system_translation_map.contains_key(string_ref)
-                        {
-                            system_translation_map.shift_insert(system_lines_ref.len() - 1, string_ref, "");
+                        if processing_mode == ProcessingMode::Append && !lines_map.contains_key(string_ref) {
+                            lines_map.shift_insert(lines_ref.len() - 1, string_ref, "");
                         }
                     }
                 }
@@ -1215,17 +1149,17 @@ pub fn read_system(
                 let str: &str = message_string.as_str().unwrap().trim();
 
                 if !str.is_empty() {
-                    let mut string: String = str.to_string();
+                    let mut string: String = str.to_owned();
 
                     if romanize {
                         string = romanize_string(string)
                     }
 
-                    system_lines_mut_ref.insert(string);
-                    let string_ref: &str = unsafe { system_lines_ref.last().unwrap_unchecked() }.as_str();
+                    lines_mut_ref.insert(string);
+                    let string_ref: &str = unsafe { lines_ref.last().unwrap_unchecked() }.as_str();
 
-                    if processing_mode == ProcessingMode::Append && !system_translation_map.contains_key(string_ref) {
-                        system_translation_map.shift_insert(system_lines_ref.len() - 1, string_ref, "");
+                    if processing_mode == ProcessingMode::Append && !lines_map.contains_key(string_ref) {
+                        lines_map.shift_insert(lines_ref.len() - 1, string_ref, "");
                     }
                 }
             }
@@ -1234,21 +1168,21 @@ pub fn read_system(
 
     // Weapon types names
     // Normally it's system strings, but might be needed for some purposes
-    for string in system_obj[weapon_types_label].as_array().unwrap() {
+    for string in obj[weapon_types_label].as_array().unwrap() {
         let str: &str = string.as_str().unwrap().trim();
 
         if !str.is_empty() {
-            let mut string: String = str.to_string();
+            let mut string: String = str.to_owned();
 
             if romanize {
                 string = romanize_string(string)
             }
 
-            system_lines_mut_ref.insert(string);
-            let string_ref: &str = unsafe { system_lines_ref.last().unwrap_unchecked() }.as_str();
+            lines_mut_ref.insert(string);
+            let string_ref: &str = unsafe { lines_ref.last().unwrap_unchecked() }.as_str();
 
-            if processing_mode == ProcessingMode::Append && !system_translation_map.contains_key(string_ref) {
-                system_translation_map.shift_insert(system_lines_ref.len() - 1, string_ref, "");
+            if processing_mode == ProcessingMode::Append && !lines_map.contains_key(string_ref) {
+                lines_map.shift_insert(lines_ref.len() - 1, string_ref, "");
             }
         }
     }
@@ -1256,35 +1190,39 @@ pub fn read_system(
     // Game title, parsed just for fun
     // Translators may add something like "ELFISH TRANSLATION v1.0.0" to the title
     {
-        let mut game_title_string: String = system_obj[game_title_label].as_str().unwrap().trim().to_string();
+        let mut game_title_string: String = obj[game_title_label].as_str().unwrap().trim().to_owned();
 
         if romanize {
             game_title_string = romanize_string(game_title_string)
         }
 
-        system_lines_mut_ref.insert(game_title_string);
-        let string_ref: &str = unsafe { system_lines_ref.last().unwrap_unchecked() }.as_str();
+        lines_mut_ref.insert(game_title_string);
+        let string_ref: &str = unsafe { lines_ref.last().unwrap_unchecked() }.as_str();
 
-        if processing_mode == ProcessingMode::Append && !system_translation_map.contains_key(string_ref) {
-            system_translation_map.shift_insert(system_lines_ref.len() - 1, string_ref, "");
+        if processing_mode == ProcessingMode::Append && !lines_map.contains_key(string_ref) {
+            lines_map.shift_insert(lines_ref.len() - 1, string_ref, "");
         }
     }
 
-    let (original_content, translated_content) = if processing_mode == ProcessingMode::Append {
-        let collected: (Vec<&str>, Vec<&str>) = system_translation_map.into_iter().unzip();
-        (collected.0.join("\n"), collected.1.join("\n"))
+    let output_content: String = if processing_mode == ProcessingMode::Append {
+        lines_map
+            .into_iter()
+            .map(|(original, translated)| format!("{original}{LINES_SEPARATOR}{translated}"))
+            .collect::<Vec<_>>()
+            .join("\n")
     } else {
-        (
-            system_lines_ref.join("\n"),
-            "\n".repeat(system_lines_ref.len().saturating_sub(1)),
-        )
+        lines
+            .into_inner()
+            .into_iter()
+            .map(|line: String| line + LINES_SEPARATOR)
+            .collect::<Vec<_>>()
+            .join("\n")
     };
 
-    write(system_output_path, original_content).unwrap();
-    write(system_trans_output_path, translated_content).unwrap();
+    write(output_path, output_content).unwrap();
 
     if logging {
-        println!("{file_parsed_msg} {}.", system_file_path.display());
+        println!("{file_parsed_msg} {}", system_file_path.display());
     }
 }
 
@@ -1323,7 +1261,7 @@ pub fn read_scripts(scripts_file_path: &Path, other_path: &Path, romanize: bool,
         codes_content.push(code);
     }
 
-    let extracted_strings: IndexSet<String> = extract_strings(&codes_content.join(""), false).0;
+    let extracted_strings: Xxh3IndexSet = extract_strings(&codes_content.join(""), false).0;
 
     let regexes: [Regex; 11] = [
         unsafe { Regex::new(r"(Graphics|Data|Audio|Movies|System)\/.*\/?").unwrap_unchecked() },
@@ -1363,12 +1301,13 @@ pub fn read_scripts(scripts_file_path: &Path, other_path: &Path, romanize: bool,
         println!("{file_parsed_msg} {}", scripts_file_path.display());
     }
 
-    write(other_path.join("scripts.txt"), strings.join("\n")).unwrap();
-    write(
-        other_path.join("scripts_trans.txt"),
-        "\n".repeat(strings.len().saturating_sub(1)),
-    )
-    .unwrap();
+    let output_content: String = strings
+        .into_iter()
+        .map(|line: String| line + LINES_SEPARATOR)
+        .collect::<Vec<_>>()
+        .join("\n");
+
+    write(other_path.join("scripts.txt"), output_content).unwrap();
 }
 
 // read_plugins is not implemented and will NEVER be, as plugins can differ from each other incredibly.


### PR DESCRIPTION
Changes translation files' structure
Fixes #22 - Added support for html-like comments inside translation files
Removed `append`, `force`, `shuffle_level` arguments
`append` and `force` flags' are replaced by `processing_mode` arg
Introduced `maps_processing_mode` arg to allow different processing of maps files
